### PR TITLE
refactor(nav): migrate to Navigation Compose (NavHost)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release
-          path: app/build/outputs/apk/release/app-release.apk
+          # Push builds upload the signed APK; PR builds (no secrets) produce
+          # the unsigned one. Match either.
+          path: app/build/outputs/apk/release/*.apk
           if-no-files-found: error

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.LumaGA"
-        android:enableOnBackInvokedCallback="true">
+        android:enableOnBackInvokedCallback="false">
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
@@ -46,6 +46,18 @@ class Navigator(
         navController.popBackStack()
     }
 
+    /** Pushes [route], replacing the current top entry — for a sheet that
+     * routes onward into a pushed screen. (Push-then-pop would pop the very
+     * entry just pushed.) */
+    fun pushReplacingTop(route: Route) {
+        val top = navController.currentBackStack.value.lastOrNull() ?: return
+        lastOp = Op.PUSH
+        navController.navigate(RouteCodec.encode(route)) {
+            // popUpTo matches the *destination* id, not the entry id.
+            popUpTo(top.destination.id) { inclusive = true }
+        }
+    }
+
     fun popToRoot() {
         navController.popBackStack(RouteCodec.ROUTE_FORUM_LIST, inclusive = false)
     }

--- a/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
@@ -46,18 +46,6 @@ class Navigator(
         navController.popBackStack()
     }
 
-    /** Pushes [route], replacing the current top entry — for a sheet that
-     * routes onward into a pushed screen. (Push-then-pop would pop the very
-     * entry just pushed.) */
-    fun pushReplacingTop(route: Route) {
-        val top = navController.currentBackStack.value.lastOrNull() ?: return
-        lastOp = Op.PUSH
-        navController.navigate(RouteCodec.encode(route)) {
-            // popUpTo matches the *destination* id, not the entry id.
-            popUpTo(top.destination.id) { inclusive = true }
-        }
-    }
-
     fun popToRoot() {
         navController.popBackStack(RouteCodec.ROUTE_FORUM_LIST, inclusive = false)
     }

--- a/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/nav/Navigator.kt
@@ -1,14 +1,26 @@
 package com.bugenzhao.mnga.ui.nav
 
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 /**
- * A minimal path-based navigation stack mirroring SwiftUI's `NavigationStack`
- * semantics: screens push/pop on an observable route list, and programmatic
- * navigation (deep links, context menus) manipulates the same list.
+ * A path-based navigation stack mirroring SwiftUI's `NavigationStack`
+ * semantics, backed by Navigation Compose's [NavHostController].
+ *
+ * The public surface (push/pop/popToRoot/popTo/replace/contains/stack/size/
+ * lastOp) is unchanged; internally the route list is derived from the
+ * NavController back stack, so programmatic navigation (deep links, context
+ * menus) and system back presses stay in sync. NavHost keeps every entry's
+ * composition and saveable state alive while it is off-screen, so popping back
+ * to a screen resumes it instead of rebuilding and refetching.
  */
-class Navigator(initial: List<Route> = emptyList()) {
+class Navigator(
+    val navController: NavHostController,
+    initial: List<Route> = emptyList(),
+) {
 
     /** How the top-most route most recently entered the stack; screens use it
      * to tell a fresh push from a pop-back (resume). */
@@ -26,31 +38,50 @@ class Navigator(initial: List<Route> = emptyList()) {
 
     fun push(route: Route) {
         lastOp = Op.PUSH
-        _stack.value = _stack.value + route
+        navController.navigate(RouteCodec.encode(route))
     }
 
     fun pop() {
         lastOp = Op.POP
-        if (_stack.value.isNotEmpty()) {
-            _stack.value = _stack.value.dropLast(1)
-        }
+        navController.popBackStack()
     }
 
     fun popToRoot() {
-        _stack.value = _stack.value.take(1)
+        navController.popBackStack(RouteCodec.ROUTE_FORUM_LIST, inclusive = false)
     }
 
     fun popTo(index: Int) {
-        if (index in _stack.value.indices && index < _stack.value.size - 1) {
-            _stack.value = _stack.value.take(index + 1)
-        }
+        val entry = navController.currentBackStack.value.getOrNull(index) ?: return
+        navController.popBackStack(entry, inclusive = false)
     }
 
     fun replace(route: Route) {
-        _stack.value = listOf(route)
+        navController.navigate(RouteCodec.encode(route)) {
+            popUpTo(navController.graph.id) { inclusive = true }
+        }
     }
 
     fun contains(predicate: (Route) -> Boolean): Boolean = _stack.value.any(predicate)
+
+    /**
+     * Keeps [stack] (and [lastOp]) in sync with the NavController back stack.
+     * Call once from composition:
+     * `LaunchedEffect(navigator) { navigator.observe(this) }`.
+     */
+    fun observe(scope: CoroutineScope) {
+        scope.launch {
+            navController.currentBackStack.collect { entries ->
+                val routes = entries.mapNotNull(RouteCodec::decode)
+                val previous = _stack.value
+                lastOp = when {
+                    routes.size > previous.size -> Op.PUSH
+                    routes.size < previous.size -> Op.POP
+                    else -> lastOp
+                }
+                _stack.value = routes
+            }
+        }
+    }
 }
 
 /** One pushed screen. */

--- a/app/src/main/java/com/bugenzhao/mnga/ui/nav/RouteCodec.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/nav/RouteCodec.kt
@@ -1,0 +1,198 @@
+package com.bugenzhao.mnga.ui.nav
+
+import android.net.Uri
+import android.os.Bundle
+import android.util.Base64
+import androidx.navigation.NavBackStackEntry
+import com.bugenzhao.mnga.protos.datamodel.ForumId
+import com.bugenzhao.mnga.protos.datamodel.User
+import org.json.JSONObject
+
+/**
+ * Maps [Route] objects to/from NavHost route strings.
+ *
+ * Every route type has its own route pattern; routes carrying arguments pack
+ * them into a single URL-encoded JSON `{payload}` path argument. NavController
+ * percent-decodes path segments when it parses a route string, so [encode]
+ * must URL-encode the payload and [decode] receives it already decoded.
+ * Decoding is defensive (runCatching): a broken payload yields null rather
+ * than crashing the stack derivation.
+ */
+object RouteCodec {
+
+    const val ROUTE_FORUM_LIST = "forum-list"
+    const val ROUTE_TOPIC_LIST = "topic-list/{payload}"
+    const val ROUTE_TOPIC_DETAILS = "topic-details/{payload}"
+    const val ROUTE_USER_PROFILE = "user-profile/{payload}"
+    const val ROUTE_GLOBAL_SEARCH = "global-search"
+    const val ROUTE_TOPIC_SEARCH = "topic-search/{payload}"
+    const val ROUTE_HOT_TOPICS = "hot-topics"
+    const val ROUTE_FAVORITES = "favorites"
+    const val ROUTE_HISTORY = "history"
+    const val ROUTE_SHORT_MESSAGES = "short-messages"
+    const val ROUTE_SHORT_MESSAGE_DETAILS = "short-message-details/{payload}"
+    const val ROUTE_SUBFORUMS = "subforums"
+    const val ROUTE_SUBFORUM_LIST = "subforum-list/{payload}"
+    const val ROUTE_UNKNOWN_FORUM = "unknown-forum/{payload}"
+    const val ROUTE_CACHE_SETTINGS = "cache-settings"
+    const val ROUTE_BLOCK_WORDS = "block-words"
+    const val ROUTE_ABOUT = "about"
+    const val ROUTE_SETTINGS = "settings"
+    const val ROUTE_NOTIFICATIONS = "notifications"
+
+    /** The route string a [Route] maps to, navigable via NavController. */
+    fun encode(route: Route): String = when (route) {
+        Route.ForumList -> ROUTE_FORUM_LIST
+        is Route.TopicList -> withPayload(ROUTE_TOPIC_LIST) {
+            putForumId("forum", route.forumId)
+            route.categoryName?.let { put("categoryName", it) }
+            if (route.mode != TopicListMode.NORMAL) put("mode", route.mode.name)
+            if (route.dateRange != 0) put("dateRange", route.dateRange)
+        }
+        is Route.TopicDetails -> withPayload(ROUTE_TOPIC_DETAILS) {
+            put("topicId", route.topicId)
+            route.fav?.let { put("fav", it) }
+            route.postId?.let { put("postId", it) }
+            route.authorId?.let { put("authorId", it) }
+            if (route.anonymousAuthorOnly) put("anon", true)
+            if (route.localCache) put("cache", true)
+            route.startPage?.let { put("startPage", it) }
+        }
+        is Route.UserProfile -> withPayload(ROUTE_USER_PROFILE) {
+            route.userId?.let { put("userId", it) }
+            route.userName?.let { put("userName", it) }
+            route.user?.let {
+                put("userB64", Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP))
+            }
+        }
+        Route.GlobalSearch -> ROUTE_GLOBAL_SEARCH
+        is Route.TopicSearch -> withPayload(ROUTE_TOPIC_SEARCH) {
+            route.forumId?.let { putForumId("forum", it) }
+        }
+        Route.HotTopics -> ROUTE_HOT_TOPICS
+        Route.Favorites -> ROUTE_FAVORITES
+        Route.History -> ROUTE_HISTORY
+        Route.ShortMessages -> ROUTE_SHORT_MESSAGES
+        is Route.ShortMessageDetails -> withPayload(ROUTE_SHORT_MESSAGE_DETAILS) {
+            put("id", route.id)
+        }
+        Route.Subforums -> ROUTE_SUBFORUMS
+        is Route.SubforumList -> withPayload(ROUTE_SUBFORUM_LIST) {
+            putForumId("forum", route.forumId)
+        }
+        is Route.UnknownForum -> withPayload(ROUTE_UNKNOWN_FORUM) {
+            route.name?.let { put("name", it) }
+        }
+        Route.CacheSettings -> ROUTE_CACHE_SETTINGS
+        Route.BlockWords -> ROUTE_BLOCK_WORDS
+        Route.About -> ROUTE_ABOUT
+        Route.Settings -> ROUTE_SETTINGS
+        Route.Notifications -> ROUTE_NOTIFICATIONS
+    }
+
+    /** Decodes the route carried by a back-stack entry; null when unparseable. */
+    fun decode(entry: NavBackStackEntry): Route? {
+        val args = entry.arguments ?: return null
+        return when (entry.destination.route) {
+            ROUTE_FORUM_LIST -> Route.ForumList
+            ROUTE_TOPIC_LIST -> decodePayload(args) { decodeTopicList(it) }
+            ROUTE_TOPIC_DETAILS -> decodePayload(args) { decodeTopicDetails(it) }
+            ROUTE_USER_PROFILE -> decodePayload(args) { decodeUserProfile(it) }
+            ROUTE_GLOBAL_SEARCH -> Route.GlobalSearch
+            ROUTE_TOPIC_SEARCH -> decodePayload(args) { decodeTopicSearch(it) }
+            ROUTE_HOT_TOPICS -> Route.HotTopics
+            ROUTE_FAVORITES -> Route.Favorites
+            ROUTE_HISTORY -> Route.History
+            ROUTE_SHORT_MESSAGES -> Route.ShortMessages
+            ROUTE_SHORT_MESSAGE_DETAILS -> decodePayload(args) { decodeShortMessageDetails(it) }
+            ROUTE_SUBFORUMS -> Route.Subforums
+            ROUTE_SUBFORUM_LIST -> decodePayload(args) { decodeSubforumList(it) }
+            ROUTE_UNKNOWN_FORUM -> decodePayload(args) { decodeUnknownForum(it) }
+            ROUTE_CACHE_SETTINGS -> Route.CacheSettings
+            ROUTE_BLOCK_WORDS -> Route.BlockWords
+            ROUTE_ABOUT -> Route.About
+            ROUTE_SETTINGS -> Route.Settings
+            ROUTE_NOTIFICATIONS -> Route.Notifications
+            else -> null
+        }
+    }
+
+    // -- encoding helpers -----------------------------------------------------
+
+    private fun withPayload(pattern: String, fill: JSONObject.() -> Unit): String {
+        val json = JSONObject()
+        json.fill()
+        return pattern.replace("{payload}", Uri.encode(json.toString()))
+    }
+
+    private fun JSONObject.putForumId(key: String, id: ForumId) {
+        when {
+            id.hasFid() -> put("${key}Fid", id.fid)
+            id.hasStid() -> put("${key}Stid", id.stid)
+        }
+    }
+
+    // -- decoding helpers -----------------------------------------------------
+
+    private inline fun decodePayload(
+        args: Bundle,
+        decode: (JSONObject) -> Route,
+    ): Route? {
+        val payload = args.getString("payload") ?: return null
+        return runCatching { decode(JSONObject(payload)) }.getOrNull()
+    }
+
+    private fun JSONObject.optStringOrNull(key: String): String? =
+        if (has(key) && !isNull(key)) optString(key) else null
+
+    private fun JSONObject.forumId(key: String): ForumId? = when {
+        has("${key}Fid") -> ForumId.newBuilder().setFid(getString("${key}Fid")).build()
+        has("${key}Stid") -> ForumId.newBuilder().setStid(getString("${key}Stid")).build()
+        else -> null
+    }
+
+    private fun decodeTopicList(json: JSONObject): Route.TopicList {
+        val forumId = json.forumId("forum") ?: error("missing forum id")
+        return Route.TopicList(
+            forumId = forumId,
+            categoryName = json.optStringOrNull("categoryName"),
+            mode = runCatching { TopicListMode.valueOf(json.optString("mode", TopicListMode.NORMAL.name)) }
+                .getOrDefault(TopicListMode.NORMAL),
+            dateRange = json.optInt("dateRange", 0),
+        )
+    }
+
+    private fun decodeTopicDetails(json: JSONObject): Route.TopicDetails =
+        Route.TopicDetails(
+            topicId = json.optString("topicId", ""),
+            fav = json.optStringOrNull("fav"),
+            postId = json.optStringOrNull("postId"),
+            authorId = json.optStringOrNull("authorId"),
+            anonymousAuthorOnly = json.optBoolean("anon", false),
+            localCache = json.optBoolean("cache", false),
+            startPage = if (json.has("startPage")) json.optInt("startPage") else null,
+        )
+
+    private fun decodeUserProfile(json: JSONObject): Route.UserProfile =
+        Route.UserProfile(
+            userId = json.optStringOrNull("userId"),
+            userName = json.optStringOrNull("userName"),
+            user = json.optStringOrNull("userB64")?.let { b64 ->
+                runCatching { User.parseFrom(Base64.decode(b64, Base64.NO_WRAP)) }.getOrNull()
+            },
+        )
+
+    private fun decodeTopicSearch(json: JSONObject): Route.TopicSearch =
+        Route.TopicSearch(forumId = json.forumId("forum"))
+
+    private fun decodeShortMessageDetails(json: JSONObject): Route.ShortMessageDetails =
+        Route.ShortMessageDetails(id = json.optString("id", ""))
+
+    private fun decodeSubforumList(json: JSONObject): Route.SubforumList {
+        val forumId = json.forumId("forum") ?: error("missing forum id")
+        return Route.SubforumList(forumId = forumId)
+    }
+
+    private fun decodeUnknownForum(json: JSONObject): Route.UnknownForum =
+        Route.UnknownForum(name = json.optStringOrNull("name"))
+}

--- a/app/src/main/java/com/bugenzhao/mnga/ui/post/InlineVideoPlayer.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/post/InlineVideoPlayer.kt
@@ -58,6 +58,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.bugenzhao.mnga.BuildConfig
 import com.bugenzhao.mnga.util.URLs
 import java.io.File
@@ -141,6 +144,36 @@ fun InlineVideoPlayer(
 
     DisposableEffect(player) {
         onDispose { runCatching { player.release() } }
+    }
+
+    // NavHost 中被其它页面盖住（或 App 退后台）时，本 entry 的生命周期会降级
+    // （RESUMED → CREATED），自动暂停；回来（ON_RESUME）时若离开前正在播放
+    // 则恢复。用户手动暂停的不自动恢复。
+    var resumeAfterLifecyclePause by remember(url) { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, player) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> {
+                    resumeAfterLifecyclePause =
+                        runCatching { player.isPlaying }.getOrDefault(false)
+                    if (resumeAfterLifecyclePause) {
+                        runCatching { player.pause() }
+                        isPlaying = false
+                    }
+                }
+                Lifecycle.Event.ON_RESUME -> {
+                    if (resumeAfterLifecyclePause) {
+                        resumeAfterLifecyclePause = false
+                        runCatching { player.start() }
+                        isPlaying = true
+                    }
+                }
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     fun togglePlay() {

--- a/app/src/main/java/com/bugenzhao/mnga/ui/root/LumaGARoot.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/root/LumaGARoot.kt
@@ -1,13 +1,11 @@
 package com.bugenzhao.mnga.ui.root
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -18,21 +16,25 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.bugenzhao.mnga.App
 import com.bugenzhao.mnga.model.NavigationIdentifier
 import com.bugenzhao.mnga.ui.nav.Navigator
 import com.bugenzhao.mnga.ui.nav.Route
+import com.bugenzhao.mnga.ui.nav.RouteCodec
 import com.bugenzhao.mnga.ui.nav.TopicListMode
 import com.bugenzhao.mnga.ui.screens.favorites.FavoritesScreen
 import com.bugenzhao.mnga.ui.screens.forumlist.ForumListScreen
@@ -62,7 +64,8 @@ fun LumaGARoot(onNewIntent: (android.content.Intent) -> Unit) {
         themeColor = com.bugenzhao.mnga.storage.ThemeColor.fromRaw(themeColor),
         colorSchemeMode = com.bugenzhao.mnga.storage.ColorSchemeMode.fromRaw(colorScheme),
     ) {
-        val navigator = remember { Navigator(listOf(Route.ForumList)) }
+        val navController = rememberNavController()
+        val navigator = remember { Navigator(navController, listOf(Route.ForumList)) }
         val editor = remember { com.bugenzhao.mnga.ui.editor.EditorController(appScope) }
 
         // Opaque theme background under the navigation stack: during the
@@ -112,8 +115,6 @@ private fun NavigationHost(
     navigator: Navigator,
     editor: com.bugenzhao.mnga.ui.editor.EditorController?,
 ) {
-    val stack by navigator.stack.collectAsState()
-    BackHandler(enabled = navigator.size > 1) { navigator.pop() }
     // 首页（导航栈只有根）双击返回退出：3 秒内按两次退出，第一次提示。
     // sheet/弹窗打开时它们自己的返回处理优先（后注册的 BackHandler 先触发）。
     val context = LocalContext.current
@@ -131,67 +132,92 @@ private fun NavigationHost(
             ).show()
         }
     }
-    // Keeps each route's rememberSaveable state (list data, scroll position)
-    // alive while the route is off-screen, so popping back to a screen
-    // restores it instead of rebuilding and refetching.
-    val saveableStateHolder = rememberSaveableStateHolder()
-    AnimatedContent(
-        targetState = stack.lastOrNull() ?: Route.ForumList,
-        transitionSpec = {
-            // Forward (push): the new page slides in from the right while the
-            // old one exits to the left. Backward (pop): mirrored — the new
-            // page slides in from the left and the old one exits to the right.
-            val forward =
-                stack.indexOf(initialState) != -1 &&
-                    stack.indexOf(targetState) > stack.indexOf(initialState)
-            if (forward) {
-                (slideInHorizontally(tween(280)) { it / 3 } + fadeIn(tween(280)))
-                    .togetherWith(
-                        slideOutHorizontally(tween(280)) { -it / 4 } + fadeOut(tween(280))
-                    )
-            } else {
-                (slideInHorizontally(tween(280)) { -it / 3 } + fadeIn(tween(280)))
-                    .togetherWith(
-                        slideOutHorizontally(tween(280)) { it / 4 } + fadeOut(tween(280))
-                    )
-            }
-        },
-        label = "nav",
-    ) { route ->
-        saveableStateHolder.SaveableStateProvider(routeKey(route)) {
-            Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                RouteDispatcher(navigator, route, editor)
-            }
+
+    // Derive the route stack from the NavController back stack (system back
+    // presses included), keeping navigator.stack/size/lastOp in sync.
+    LaunchedEffect(navigator) { navigator.observe(this) }
+
+    NavHost(
+        navController = navigator.navController,
+        startDestination = RouteCodec.ROUTE_FORUM_LIST,
+        modifier = Modifier.fillMaxSize(),
+        // Forward (push): the new page slides in from the right while the old
+        // one exits to the left. Backward (pop): mirrored.
+        enterTransition = { slideInHorizontally(tween(280)) { it / 3 } + fadeIn(tween(280)) },
+        exitTransition = { slideOutHorizontally(tween(280)) { -it / 4 } + fadeOut(tween(280)) },
+        popEnterTransition = { slideInHorizontally(tween(280)) { -it / 3 } + fadeIn(tween(280)) },
+        popExitTransition = { slideOutHorizontally(tween(280)) { it / 4 } + fadeOut(tween(280)) },
+    ) {
+        composable(RouteCodec.ROUTE_FORUM_LIST) {
+            RouteDispatcher(navigator, Route.ForumList, editor)
+        }
+        composable(RouteCodec.ROUTE_TOPIC_LIST, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_TOPIC_DETAILS, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_USER_PROFILE, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_GLOBAL_SEARCH) {
+            RouteDispatcher(navigator, Route.GlobalSearch, editor)
+        }
+        composable(RouteCodec.ROUTE_TOPIC_SEARCH, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_HOT_TOPICS) {
+            RouteDispatcher(navigator, Route.HotTopics, editor)
+        }
+        composable(RouteCodec.ROUTE_FAVORITES) {
+            RouteDispatcher(navigator, Route.Favorites, editor)
+        }
+        composable(RouteCodec.ROUTE_HISTORY) {
+            RouteDispatcher(navigator, Route.History, editor)
+        }
+        composable(RouteCodec.ROUTE_SHORT_MESSAGES) {
+            RouteDispatcher(navigator, Route.ShortMessages, editor)
+        }
+        composable(RouteCodec.ROUTE_SHORT_MESSAGE_DETAILS, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_SUBFORUMS) {
+            RouteDispatcher(navigator, Route.Subforums, editor)
+        }
+        composable(RouteCodec.ROUTE_SUBFORUM_LIST, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_UNKNOWN_FORUM, arguments = payloadArgument) { entry ->
+            val route = remember(entry) { RouteCodec.decode(entry) }
+            if (route != null) RouteDispatcher(navigator, route, editor)
+        }
+        composable(RouteCodec.ROUTE_CACHE_SETTINGS) {
+            RouteDispatcher(navigator, Route.CacheSettings, editor)
+        }
+        composable(RouteCodec.ROUTE_BLOCK_WORDS) {
+            RouteDispatcher(navigator, Route.BlockWords, editor)
+        }
+        composable(RouteCodec.ROUTE_ABOUT) {
+            RouteDispatcher(navigator, Route.About, editor)
+        }
+        composable(RouteCodec.ROUTE_SETTINGS) {
+            RouteDispatcher(navigator, Route.Settings, editor)
+        }
+        composable(RouteCodec.ROUTE_NOTIFICATIONS) {
+            RouteDispatcher(navigator, Route.Notifications, editor)
         }
     }
 }
 
-/** Stable per-route key for [androidx.compose.runtime.saveable.rememberSaveableStateHolder]. */
-private fun routeKey(route: Route): String = when (route) {
-    Route.ForumList -> "forum-list"
-    is Route.TopicList ->
-        "topic-list-${if (route.forumId.hasFid()) "f${route.forumId.fid}" else "st${route.forumId.stid}"}-${route.mode}"
-    is Route.TopicDetails ->
-        "topic-details-${route.topicId}-${route.postId ?: ""}${if (route.anonymousAuthorOnly) "-anon" else ""}-${route.authorId ?: ""}${if (route.localCache) "-cache" else ""}"
-    is Route.UserProfile -> "user-profile-${route.userId ?: route.userName ?: "?"}"
-    Route.GlobalSearch -> "global-search"
-    is Route.TopicSearch ->
-        "topic-search-" + (route.forumId?.let { if (it.hasFid()) "f${it.fid}" else "st${it.stid}" } ?: "all")
-    Route.HotTopics -> "hot-topics"
-    Route.Favorites -> "favorites"
-    Route.History -> "history"
-    Route.ShortMessages -> "short-messages"
-    is Route.ShortMessageDetails -> "short-message-details-${route.id}"
-    Route.Subforums -> "subforums"
-    is Route.SubforumList ->
-        "subforum-list-${if (route.forumId.hasFid()) "f${route.forumId.fid}" else "st${route.forumId.stid}"}"
-    is Route.UnknownForum -> "unknown-forum"
-    Route.CacheSettings -> "cache-settings"
-    Route.BlockWords -> "block-words"
-    Route.About -> "about"
-    Route.Settings -> "settings"
-    Route.Notifications -> "notifications"
-}
+/** Every argument-carrying route packs its fields into one JSON `payload` path arg. */
+private val payloadArgument =
+    listOf(navArgument("payload") { type = NavType.StringType })
 
 /** Maps a route to its screen. */
 @Composable
@@ -222,8 +248,8 @@ fun RouteDispatcher(
                 userName = route.userName,
                 user = route.user,
             )
-        is Route.GlobalSearch -> SearchScreen(navigator, freshEntry = navigator.lastOp == Navigator.Op.PUSH)
-        is Route.TopicSearch -> SearchScreen(navigator, route.forumId, freshEntry = navigator.lastOp == Navigator.Op.PUSH)
+        is Route.GlobalSearch -> SearchScreen(navigator)
+        is Route.TopicSearch -> SearchScreen(navigator, route.forumId)
         is Route.Favorites -> FavoritesScreen(navigator)
         is Route.History -> HistoryScreen(navigator)
         is Route.ShortMessages -> ShortMessageListScreen(navigator)

--- a/app/src/main/java/com/bugenzhao/mnga/ui/root/LumaGARoot.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/root/LumaGARoot.kt
@@ -237,7 +237,6 @@ fun RouteDispatcher(
                     ?: route.mode,
                 dateRange = route.dateRange,
                 editor = editor,
-                route = route,
             )
         is Route.TopicDetails ->
             TopicDetailsScreen(navigator, route, editor = editor)

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesScreen.kt
@@ -1,5 +1,6 @@
 package com.bugenzhao.mnga.ui.screens.favorites
 
+import android.util.Base64
 import androidx.activity.compose.BackHandler
 
 import androidx.compose.foundation.layout.Arrangement
@@ -51,6 +52,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -153,20 +157,43 @@ fun FavoritesScreen(navigator: Navigator, initialFolderId: String? = null) {
     val foldersModel = remember { FavoriteFoldersModel(scope) }
     val folders by foldersModel.folders.collectAsState()
     var currentFolder by remember { mutableStateOf<FavoriteTopicFolder?>(null) }
+    // 记住上次选择的文件夹：返回本页时恢复该选择，而不是跳回默认文件夹。
+    var savedFolderId by rememberSaveable { mutableStateOf<String?>(null) }
+    // 文件夹列表快照：返回本页时不重新拉取（NavHost 下组合重建）。
+    var savedFoldersB64 by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
 
     // Load folders on entry, keeping the previous selection when possible.
     LaunchedEffect(Unit) {
         if (currentFolder == null) {
-            foldersModel.load(force = true)
+            if (savedFoldersB64.isNotEmpty()) {
+                foldersModel.folders.value = savedFoldersB64.map {
+                    FavoriteTopicFolder.parseFrom(Base64.decode(it, Base64.NO_WRAP))
+                }
+            } else {
+                foldersModel.load(force = true)
+            }
+        }
+    }
+    // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
+    // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        if (foldersModel.folders.value.isNotEmpty()) {
+            savedFoldersB64 = foldersModel.folders.value.map {
+                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
+            }
         }
     }
     LaunchedEffect(folders) {
         if (folders.isNotEmpty()) {
             val restored = folders.firstOrNull { it.id == currentFolder?.id }
+                ?: savedFolderId?.let { id -> folders.firstOrNull { it.id == id } }
                 ?: folders.firstOrNull { it.id == initialFolderId }
                 ?: folders.firstOrNull { it.isDefault }
                 ?: folders.first()
-            if (restored.id != currentFolder?.id) currentFolder = restored
+            if (restored.id != currentFolder?.id) {
+                currentFolder = restored
+                savedFolderId = restored.id
+            }
         } else if (currentFolder != null && folders.none { it.id == currentFolder?.id }) {
             currentFolder = null
         }
@@ -236,6 +263,7 @@ fun FavoritesScreen(navigator: Navigator, initialFolderId: String? = null) {
                                 PlusModel.checkPlus(PlusFeature.MULTI_FAVORITE)
                             ) {
                                 currentFolder = folder
+                                savedFolderId = folder.id
                             }
                         },
                         onMakeDefault = { modifyCurrent { it.setSetDefault(true) } },
@@ -469,7 +497,40 @@ private fun FavoriteTopicList(folder: FavoriteTopicFolder, navigator: Navigator)
         )
     }
     val state by dataSource.state.collectAsState()
-    LaunchedEffect(folder.id) { dataSource.initialLoad() }
+
+    // -- 跨路由保留：被详情页盖住时保存快照，返回时恢复而不是重新拉取
+    // （NavHost 下 entry 组合销毁重建，普通 remember 数据源会重建为空）。
+    var savedItemsB64 by rememberSaveable(folder.id) { mutableStateOf<List<String>>(emptyList()) }
+    var savedLoadedPage by rememberSaveable(folder.id) { mutableStateOf(0) }
+    var savedTotalPages by rememberSaveable(folder.id) { mutableStateOf(1) }
+    var savedLastRefresh by rememberSaveable(folder.id) { mutableStateOf(0L) }
+
+    LaunchedEffect(folder.id) {
+        if (savedItemsB64.isNotEmpty()) {
+            dataSource.restoreItems(
+                items = savedItemsB64.map {
+                    Topic.parseFrom(Base64.decode(it, Base64.NO_WRAP))
+                },
+                loadedPage = savedLoadedPage,
+                totalPages = savedTotalPages,
+                lastRefreshTime = savedLastRefresh.takeIf { it > 0 }?.let { java.util.Date(it) },
+            )
+        } else {
+            dataSource.initialLoad()
+        }
+    }
+    // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
+    // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        if (dataSource.items.isNotEmpty()) {
+            savedItemsB64 = dataSource.items.map {
+                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
+            }
+            savedLoadedPage = dataSource.loadedPage
+            savedTotalPages = dataSource.totalPages
+            savedLastRefresh = dataSource.lastRefreshTime?.time ?: 0L
+        }
+    }
 
     // Rows hidden after a successful swipe-delete.
     val hiddenIds = remember(folder.id) { mutableStateListOf<String>() }

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesScreen.kt
@@ -1,6 +1,5 @@
 package com.bugenzhao.mnga.ui.screens.favorites
 
-import android.util.Base64
 import androidx.activity.compose.BackHandler
 
 import androidx.compose.foundation.layout.Arrangement
@@ -52,9 +51,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.bugenzhao.mnga.logicCallAsync
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -62,21 +60,12 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.bugenzhao.mnga.logicCallAsync
-import com.bugenzhao.mnga.model.PagingDataSource
 import com.bugenzhao.mnga.model.PlusFeature
 import com.bugenzhao.mnga.model.PlusModel
 import com.bugenzhao.mnga.protos.datamodel.FavoriteTopicFolder
 import com.bugenzhao.mnga.protos.datamodel.Topic
 import com.bugenzhao.mnga.protos.service.AsyncRequest
-import com.bugenzhao.mnga.protos.service.FavoriteFolderCreateRequest
-import com.bugenzhao.mnga.protos.service.FavoriteFolderCreateResponse
-import com.bugenzhao.mnga.protos.service.FavoriteFolderListRequest
-import com.bugenzhao.mnga.protos.service.FavoriteFolderListResponse
 import com.bugenzhao.mnga.protos.service.FavoriteFolderModifyRequest
-import com.bugenzhao.mnga.protos.service.FavoriteFolderModifyResponse
-import com.bugenzhao.mnga.protos.service.FavoriteTopicListRequest
-import com.bugenzhao.mnga.protos.service.FavoriteTopicListResponse
 import com.bugenzhao.mnga.protos.service.TopicFavorRequest
 import com.bugenzhao.mnga.protos.service.TopicFavorResponse
 import com.bugenzhao.mnga.ui.components.AdaptiveFooter
@@ -87,55 +76,7 @@ import com.bugenzhao.mnga.ui.nav.Route
 import com.bugenzhao.mnga.ui.screens.topiclist.TopicRow
 import com.bugenzhao.mnga.util.Haptics
 import com.bugenzhao.mnga.util.L
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-
-/**
- * Favorite folders state holder, a port of the `FavoriteFolderModel` singleton
- * scoped to this screen.
- */
-private class FavoriteFoldersModel(private val scope: CoroutineScope) {
-    val folders = MutableStateFlow<List<FavoriteTopicFolder>>(emptyList())
-
-    suspend fun load(force: Boolean = false) {
-        if (folders.value.isEmpty() || force) {
-            val result = logicCallAsync(
-                AsyncRequest.newBuilder()
-                    .setFavoriteFolderList(FavoriteFolderListRequest.getDefaultInstance())
-                    .build(),
-                FavoriteFolderListResponse.parser(),
-            )
-            result.onSuccess { response -> folders.value = response.foldersList }
-        }
-    }
-
-    suspend fun modify(request: FavoriteFolderModifyRequest): Boolean {
-        val result = logicCallAsync(
-            AsyncRequest.newBuilder().setFavoriteFolderModify(request).build(),
-            FavoriteFolderModifyResponse.parser(),
-        )
-        return if (result.isSuccess) {
-            load(force = true)
-            true
-        } else {
-            false
-        }
-    }
-
-    /** Creates a folder and returns its id, or null on failure. */
-    suspend fun create(name: String): String? {
-        val result = logicCallAsync(
-            AsyncRequest.newBuilder()
-                .setFavoriteFolderCreate(
-                    FavoriteFolderCreateRequest.newBuilder().setName(name).build()
-                )
-                .build(),
-            FavoriteFolderCreateResponse.parser(),
-        )
-        return result.getOrNull()?.folderId?.also { load(force = true) }
-    }
-}
 
 /** The default folder forced first, mirroring `sortedFolders`. */
 private fun List<FavoriteTopicFolder>.sortedFolders(): List<FavoriteTopicFolder> =
@@ -154,45 +95,29 @@ fun FavoritesScreen(navigator: Navigator, initialFolderId: String? = null) {
     val scope = rememberCoroutineScope()
     BackHandler(enabled = navigator.size > 1) { navigator.pop() }
 
-    val foldersModel = remember { FavoriteFoldersModel(scope) }
+    val favoritesVM: FavoritesViewModel = viewModel()
+    val foldersModel = favoritesVM.foldersModel
     val folders by foldersModel.folders.collectAsState()
     var currentFolder by remember { mutableStateOf<FavoriteTopicFolder?>(null) }
-    // 记住上次选择的文件夹：返回本页时恢复该选择，而不是跳回默认文件夹。
-    var savedFolderId by rememberSaveable { mutableStateOf<String?>(null) }
-    // 文件夹列表快照：返回本页时不重新拉取（NavHost 下组合重建）。
-    var savedFoldersB64 by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
 
     // Load folders on entry, keeping the previous selection when possible.
+    // The ViewModel (and the loaded folder list) survives pop-backs, so only
+    // a first entry or process death triggers a fetch.
     LaunchedEffect(Unit) {
-        if (currentFolder == null) {
-            if (savedFoldersB64.isNotEmpty()) {
-                foldersModel.folders.value = savedFoldersB64.map {
-                    FavoriteTopicFolder.parseFrom(Base64.decode(it, Base64.NO_WRAP))
-                }
-            } else {
-                foldersModel.load(force = true)
-            }
-        }
-    }
-    // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
-    // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
-    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
-        if (foldersModel.folders.value.isNotEmpty()) {
-            savedFoldersB64 = foldersModel.folders.value.map {
-                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
-            }
+        if (currentFolder == null && foldersModel.folders.value.isEmpty()) {
+            foldersModel.load(force = true)
         }
     }
     LaunchedEffect(folders) {
         if (folders.isNotEmpty()) {
             val restored = folders.firstOrNull { it.id == currentFolder?.id }
-                ?: savedFolderId?.let { id -> folders.firstOrNull { it.id == id } }
+                ?: favoritesVM.currentFolderId?.let { id -> folders.firstOrNull { it.id == id } }
                 ?: folders.firstOrNull { it.id == initialFolderId }
                 ?: folders.firstOrNull { it.isDefault }
                 ?: folders.first()
             if (restored.id != currentFolder?.id) {
                 currentFolder = restored
-                savedFolderId = restored.id
+                favoritesVM.currentFolderId = restored.id
             }
         } else if (currentFolder != null && folders.none { it.id == currentFolder?.id }) {
             currentFolder = null
@@ -263,7 +188,7 @@ fun FavoritesScreen(navigator: Navigator, initialFolderId: String? = null) {
                                 PlusModel.checkPlus(PlusFeature.MULTI_FAVORITE)
                             ) {
                                 currentFolder = folder
-                                savedFolderId = folder.id
+                                favoritesVM.currentFolderId = folder.id
                             }
                         },
                         onMakeDefault = { modifyCurrent { it.setSetDefault(true) } },
@@ -476,60 +401,17 @@ private fun FavoriteTopicList(folder: FavoriteTopicFolder, navigator: Navigator)
     val view = LocalView.current
     val scope = rememberCoroutineScope()
 
-    val dataSource = remember(folder.id) {
-        PagingDataSource<FavoriteTopicListResponse, Topic>(
-            scope = scope,
-            responseParser = { FavoriteTopicListResponse.parser() },
-            buildRequest = { page ->
-                AsyncRequest.newBuilder()
-                    .setFavoriteTopicList(
-                        FavoriteTopicListRequest.newBuilder()
-                            .setFolderId(folder.id)
-                            .setPage(page)
-                            .build()
-                    )
-                    .build()
-            },
-            onResponse = { response ->
-                Pair(response.topicsList, response.pages.toInt().takeIf { it > 0 })
-            },
-            id = { it.id },
-        )
-    }
+    // The per-folder paged list lives in the entry-scoped ViewModel: it
+    // survives pop-backs (composition is disposed, ViewModel is not), so
+    // returning here does not refetch.
+    val favoritesVM: FavoritesViewModel = viewModel()
+    val dataSource = favoritesVM.topicDataSource(folder.id)
     val state by dataSource.state.collectAsState()
 
-    // -- 跨路由保留：被详情页盖住时保存快照，返回时恢复而不是重新拉取
-    // （NavHost 下 entry 组合销毁重建，普通 remember 数据源会重建为空）。
-    var savedItemsB64 by rememberSaveable(folder.id) { mutableStateOf<List<String>>(emptyList()) }
-    var savedLoadedPage by rememberSaveable(folder.id) { mutableStateOf(0) }
-    var savedTotalPages by rememberSaveable(folder.id) { mutableStateOf(1) }
-    var savedLastRefresh by rememberSaveable(folder.id) { mutableStateOf(0L) }
-
+    // Load on first entry only: after a pop-back the ViewModel still holds
+    // the data, so notLoaded is false and nothing is refetched.
     LaunchedEffect(folder.id) {
-        if (savedItemsB64.isNotEmpty()) {
-            dataSource.restoreItems(
-                items = savedItemsB64.map {
-                    Topic.parseFrom(Base64.decode(it, Base64.NO_WRAP))
-                },
-                loadedPage = savedLoadedPage,
-                totalPages = savedTotalPages,
-                lastRefreshTime = savedLastRefresh.takeIf { it > 0 }?.let { java.util.Date(it) },
-            )
-        } else {
-            dataSource.initialLoad()
-        }
-    }
-    // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
-    // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
-    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
-        if (dataSource.items.isNotEmpty()) {
-            savedItemsB64 = dataSource.items.map {
-                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
-            }
-            savedLoadedPage = dataSource.loadedPage
-            savedTotalPages = dataSource.totalPages
-            savedLastRefresh = dataSource.lastRefreshTime?.time ?: 0L
-        }
+        if (dataSource.notLoaded) dataSource.initialLoad()
     }
 
     // Rows hidden after a successful swipe-delete.

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/favorites/FavoritesViewModel.kt
@@ -1,0 +1,111 @@
+package com.bugenzhao.mnga.ui.screens.favorites
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bugenzhao.mnga.logicCallAsync
+import com.bugenzhao.mnga.model.PagingDataSource
+import com.bugenzhao.mnga.protos.datamodel.FavoriteTopicFolder
+import com.bugenzhao.mnga.protos.datamodel.Topic
+import com.bugenzhao.mnga.protos.service.AsyncRequest
+import com.bugenzhao.mnga.protos.service.FavoriteFolderCreateRequest
+import com.bugenzhao.mnga.protos.service.FavoriteFolderCreateResponse
+import com.bugenzhao.mnga.protos.service.FavoriteFolderListRequest
+import com.bugenzhao.mnga.protos.service.FavoriteFolderListResponse
+import com.bugenzhao.mnga.protos.service.FavoriteFolderModifyRequest
+import com.bugenzhao.mnga.protos.service.FavoriteFolderModifyResponse
+import com.bugenzhao.mnga.protos.service.FavoriteTopicListRequest
+import com.bugenzhao.mnga.protos.service.FavoriteTopicListResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/** Favorite folders of the logged-in user (SS15). */
+class FavoriteFoldersModel(private val scope: CoroutineScope) {
+    val folders = MutableStateFlow<List<FavoriteTopicFolder>>(emptyList())
+
+    suspend fun load(force: Boolean = false) {
+        if (folders.value.isEmpty() || force) {
+            val result = logicCallAsync(
+                AsyncRequest.newBuilder()
+                    .setFavoriteFolderList(FavoriteFolderListRequest.getDefaultInstance())
+                    .build(),
+                FavoriteFolderListResponse.parser(),
+            )
+            result.onSuccess { response -> folders.value = response.foldersList }
+        }
+    }
+
+    suspend fun modify(request: FavoriteFolderModifyRequest): Boolean {
+        val result = logicCallAsync(
+            AsyncRequest.newBuilder().setFavoriteFolderModify(request).build(),
+            FavoriteFolderModifyResponse.parser(),
+        )
+        return if (result.isSuccess) {
+            load(force = true)
+            true
+        } else {
+            false
+        }
+    }
+
+    /** Creates a folder and returns its id, or null on failure. */
+    suspend fun create(name: String): String? {
+        val result = logicCallAsync(
+            AsyncRequest.newBuilder()
+                .setFavoriteFolderCreate(
+                    FavoriteFolderCreateRequest.newBuilder().setName(name).build()
+                )
+                .build(),
+            FavoriteFolderCreateResponse.parser(),
+        )
+        return result.getOrNull()?.folderId?.also { load(force = true) }
+    }
+}
+
+/**
+ * Entry-scoped holder of the favorites screen state.
+ *
+ * NavHost scopes [ViewModel]s to the back-stack entry: when the entry is
+ * covered, its composition is disposed but the ViewModel (folders, the
+ * selected folder id, loaded topic lists) survives, so popping back reuses
+ * it instead of refetching — no manual snapshot needed. The selected folder
+ * id lives in [SavedStateHandle] so it also survives process death.
+ */
+class FavoritesViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    val foldersModel = FavoriteFoldersModel(viewModelScope)
+
+    /** The folder the user last selected; kept across pop-backs and process death. */
+    var currentFolderId: String?
+        get() = savedStateHandle["currentFolderId"]
+        set(value) {
+            savedStateHandle["currentFolderId"] = value
+        }
+
+    // One paged topic list per folder, cached so switching folders back and
+    // forth does not refetch. Folders are few, so the cache is small.
+    private val topicSources =
+        mutableMapOf<String, PagingDataSource<FavoriteTopicListResponse, Topic>>()
+
+    fun topicDataSource(folderId: String): PagingDataSource<FavoriteTopicListResponse, Topic> =
+        topicSources.getOrPut(folderId) {
+            PagingDataSource(
+                scope = viewModelScope,
+                responseParser = { FavoriteTopicListResponse.parser() },
+                buildRequest = { page ->
+                    AsyncRequest.newBuilder()
+                        .setFavoriteTopicList(
+                            FavoriteTopicListRequest.newBuilder()
+                                .setFolderId(folderId)
+                                .setPage(page)
+                                .build()
+                        )
+                        .build()
+                },
+                onResponse = { response ->
+                    Pair(response.topicsList, response.pages.toInt().takeIf { it > 0 })
+                },
+                id = { it.id },
+            )
+        }
+}

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/forumlist/ForumListScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/forumlist/ForumListScreen.kt
@@ -55,14 +55,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -77,12 +75,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bugenzhao.mnga.App
 import com.bugenzhao.mnga.model.NavigationIdentifier
-import com.bugenzhao.mnga.model.PagingDataSource
-import com.bugenzhao.mnga.protos.datamodel.Category
 import com.bugenzhao.mnga.protos.datamodel.Forum
 import com.bugenzhao.mnga.protos.service.AsyncRequest
-import com.bugenzhao.mnga.protos.service.ForumListRequest
-import com.bugenzhao.mnga.protos.service.ForumListResponse
 import com.bugenzhao.mnga.ui.components.Avatar
 import com.bugenzhao.mnga.ui.components.LoadingRow
 import com.bugenzhao.mnga.ui.nav.Navigator
@@ -94,6 +88,7 @@ import com.bugenzhao.mnga.ui.screens.topiclist.shareText
 import com.bugenzhao.mnga.storage.FilterMode
 import com.bugenzhao.mnga.util.Haptics
 import com.bugenzhao.mnga.util.L
+import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 
 private const val CollapsedCategoriesKey = "collapsedCategories"
@@ -117,52 +112,21 @@ fun ForumListScreen(
     val view = LocalView.current
     val scope = rememberCoroutineScope()
 
-    // -- Data: all forum categories.
-    val dataSource = remember {
-        PagingDataSource<ForumListResponse, Category>(
-            scope = scope,
-            responseParser = { ForumListResponse.parser() },
-            buildRequest = {
-                AsyncRequest.newBuilder()
-                    .setForumList(ForumListRequest.getDefaultInstance())
-                    .build()
-            },
-            onResponse = { response -> Pair(response.categoriesList, 1) },
-            id = { it.id },
-        )
-    }
+    // -- Data: all forum categories, held by the entry-scoped ViewModel so it
+    // survives being covered by a pushed screen (composition is disposed,
+    // ViewModel is not) — no snapshot needed.
+    val forumListVM: ForumListViewModel = viewModel()
+    val dataSource = forumListVM.dataSource
     val state by dataSource.state.collectAsState()
     val categories = state.items
 
-    // -- Keep the loaded forum list across navigation: when this screen is
-    // pushed away (e.g. into a topic list) and popped back, restore the
-    // previous items instead of refetching (the screen is recreated by the
-    // navigation host, which would otherwise reload and flash).
-    var savedItemsB64 by rememberSaveable { mutableStateOf<List<String>>(emptyList()) }
-    var savedRefreshTime by rememberSaveable { mutableStateOf(0L) }
+    // Load (and sync favorites) on first entry only: after a pop-back the
+    // ViewModel still holds the data, so notLoaded is false and nothing is
+    // refetched.
     LaunchedEffect(dataSource) {
-        if (savedItemsB64.isNotEmpty()) {
-            dataSource.restoreItems(
-                items = savedItemsB64.map {
-                    Category.parseFrom(android.util.Base64.decode(it, android.util.Base64.NO_WRAP))
-                },
-                loadedPage = 1,
-                totalPages = 1,
-                lastRefreshTime = savedRefreshTime.takeIf { it > 0 }?.let { java.util.Date(it) },
-            )
-        } else {
+        if (dataSource.notLoaded) {
             dataSource.initialLoad()
             App.favoriteForums.initialSync()
-        }
-    }
-    DisposableEffect(Unit) {
-        onDispose {
-            if (dataSource.items.isNotEmpty()) {
-                savedItemsB64 = dataSource.items.map {
-                    android.util.Base64.encodeToString(it.toByteArray(), android.util.Base64.NO_WRAP)
-                }
-                savedRefreshTime = state.lastRefreshTime?.time ?: 0L
-            }
         }
     }
 
@@ -192,10 +156,6 @@ fun ForumListScreen(
     fun toggleFavorite(forum: Forum) {
         App.favoriteForums.toggle(forum) { Haptics.lightImpact(view) }
     }
-
-    // -- Initial load, favorites sync on auth change.
-    val authInfo by App.authStorage.authInfo.collectAsState()
-    LaunchedEffect(authInfo) { App.favoriteForums.sync() }
 
     // -- Toolbar state.
     val currentUser by App.currentUser.user.collectAsState()

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/forumlist/ForumListViewModel.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/forumlist/ForumListViewModel.kt
@@ -1,0 +1,42 @@
+package com.bugenzhao.mnga.ui.screens.forumlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bugenzhao.mnga.App
+import com.bugenzhao.mnga.model.PagingDataSource
+import com.bugenzhao.mnga.protos.datamodel.Category
+import com.bugenzhao.mnga.protos.service.AsyncRequest
+import com.bugenzhao.mnga.protos.service.ForumListRequest
+import com.bugenzhao.mnga.protos.service.ForumListResponse
+import kotlinx.coroutines.launch
+
+/**
+ * Entry-scoped holder of the root forum-list data.
+ *
+ * NavHost scopes [ViewModel]s to the back-stack entry: when the entry is
+ * covered by a pushed screen its composition is disposed but the ViewModel
+ * (and the loaded categories) survives, so popping back to the home screen
+ * does not refetch or re-sync the favorite forums.
+ */
+class ForumListViewModel : ViewModel() {
+
+    val dataSource = PagingDataSource<ForumListResponse, Category>(
+        scope = viewModelScope,
+        responseParser = { ForumListResponse.parser() },
+        buildRequest = {
+            AsyncRequest.newBuilder()
+                .setForumList(ForumListRequest.getDefaultInstance())
+                .build()
+        },
+        onResponse = { response -> Pair(response.categoriesList, 1) },
+        id = { it.id },
+    )
+
+    init {
+        // 登录状态变化时同步收藏版块。放在 ViewModel 里观察一次：组合重建
+        // （返回本页）不会重新触发，而原来的 LaunchedEffect(authInfo) 会。
+        viewModelScope.launch {
+            App.authStorage.authInfo.collect { App.favoriteForums.sync() }
+        }
+    }
+}

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/notifications/NotificationListSheet.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/notifications/NotificationListSheet.kt
@@ -233,10 +233,8 @@ fun NotificationListSheet(
                                 read = read,
                                 onClick = {
                                     mark(listOf(noti.id), read = true)
-                                    // 不能先 push 再 pop：NavController 的 pop 会
-                                    // 弹掉刚 push 的 entry，页面留在原地。用"替换
-                                    // 顶部"让通知页直接路由到目标页。
-                                    navigator.pushReplacingTop(routeForNotification(noti))
+                                    // 与其它列表页一致：push 详情，返回时回到通知列表。
+                                    navigator.push(routeForNotification(noti))
                                 },
                                 onToggleRead = { mark(listOf(noti.id), read = !read) },
                             )

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/notifications/NotificationListSheet.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/notifications/NotificationListSheet.kt
@@ -233,8 +233,10 @@ fun NotificationListSheet(
                                 read = read,
                                 onClick = {
                                     mark(listOf(noti.id), read = true)
-                                    navigateForNotification(navigator, noti)
-                                    onDismiss()
+                                    // 不能先 push 再 pop：NavController 的 pop 会
+                                    // 弹掉刚 push 的 entry，页面留在原地。用"替换
+                                    // 顶部"让通知页直接路由到目标页。
+                                    navigator.pushReplacingTop(routeForNotification(noti))
                                 },
                                 onToggleRead = { mark(listOf(noti.id), read = !read) },
                             )
@@ -247,19 +249,15 @@ fun NotificationListSheet(
 }
 
 /** Route per `NotificationListView.buildLink`. */
-private fun navigateForNotification(navigator: Navigator, noti: Notification) {
-    when (noti.type) {
-        Notification.Type.SHORT_MESSAGE, Notification.Type.SHORT_MESSAGE_START ->
-            // The SM conversation id is carried in `otherPostID.tid`.
-            navigator.push(Route.ShortMessageDetails(id = noti.otherPostId.tid))
-        else -> navigator.push(
-            Route.TopicDetails(
-                topicId = noti.otherPostId.tid,
-                postId = noti.otherPostId.pid.takeIf { it.isNotEmpty() },
-                startPage = noti.page.toInt().takeIf { it > 0 } ?: 1,
-            )
-        )
-    }
+private fun routeForNotification(noti: Notification): Route = when (noti.type) {
+    Notification.Type.SHORT_MESSAGE, Notification.Type.SHORT_MESSAGE_START ->
+        // The SM conversation id is carried in `otherPostID.tid`.
+        Route.ShortMessageDetails(id = noti.otherPostId.tid)
+    else -> Route.TopicDetails(
+        topicId = noti.otherPostId.tid,
+        postId = noti.otherPostId.pid.takeIf { it.isNotEmpty() },
+        startPage = noti.page.toInt().takeIf { it > 0 } ?: 1,
+    )
 }
 
 /** One notification row, ported from `NotificationRowView`. */

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchResults.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchResults.kt
@@ -125,7 +125,6 @@ internal fun buildTopicSearchDataSource(
 internal fun ForumResultsList(
     dataSource: PagingDataSource<ForumSearchResponse, Forum>,
     navigator: Navigator,
-    freshEntry: Boolean = false,
 ) {
     val context = LocalContext.current
     val state by dataSource.state.collectAsState()
@@ -161,10 +160,6 @@ internal fun ForumResultsList(
             else -> {
                 // Saveable：pop 返回时恢复滚动位置（resume 效果）。
                 val lstate = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
-                // 全新进入：即便 saveable 残留了上次的位置也重置到顶部。
-                if (freshEntry) {
-                    LaunchedEffect(Unit) { lstate.scrollToItem(0) }
-                }
                 LazyColumn(
                     state = lstate,
                     modifier = Modifier.fillMaxSize(),
@@ -188,7 +183,6 @@ internal fun ForumResultsList(
 internal fun TopicResultsList(
     dataSource: PagingDataSource<TopicSearchResponse, Topic>,
     navigator: Navigator,
-    freshEntry: Boolean = false,
 ) {
     val context = LocalContext.current
     val view = LocalView.current
@@ -221,10 +215,6 @@ internal fun TopicResultsList(
             else -> {
                 // Saveable：pop 返回时恢复滚动位置（resume 效果）。
                 val lstate = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
-                // 全新进入：即便 saveable 残留了上次的位置也重置到顶部。
-                if (freshEntry) {
-                    LaunchedEffect(Unit) { lstate.scrollToItem(0) }
-                }
                 LazyColumn(
                     state = lstate,
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
@@ -122,7 +122,7 @@ fun SearchScreen(
     var committedText by rememberSaveable { mutableStateOf<String?>(null) }
     // Narrowed to the browsed forum by default, where there is one to narrow to.
     var currentForumOnly by rememberSaveable { mutableStateOf(forumId != null) }
-    var searchContent by rememberSaveable { mutableStateOf(true) }
+    var searchContent by rememberSaveable { mutableStateOf(false) }
 
     // 结果快照：进详情返回时恢复列表数据（dataSource 是普通 remember，离开组合
     // 会重建为空；与列表页的跨路由状态保留是同一机制）。

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
@@ -80,7 +80,8 @@ import com.bugenzhao.mnga.protos.datamodel.Topic
 import com.bugenzhao.mnga.protos.datamodel.Forum
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.bugenzhao.mnga.storage.SearchHistoryScope
 import com.bugenzhao.mnga.ui.nav.Navigator
 import com.bugenzhao.mnga.util.L
@@ -185,23 +186,25 @@ fun SearchScreen(
             ds.initialLoad()
         }
     }
-    DisposableEffect(Unit) {
-        onDispose {
-            topicDataSource?.let { ds ->
-                if (ds.items.isNotEmpty()) {
-                    savedTopicsB64 = ds.items.map {
-                        android.util.Base64.encodeToString(it.toByteArray(), android.util.Base64.NO_WRAP)
-                    }
-                    savedTopicsLoadedPage = ds.loadedPage
+    // 保存结果快照：entry 被盖住（NavHost 下组合销毁、返回时重建）或退后台时
+    // 写入 saveable，返回时 restoreItems 恢复而不重新拉取。
+    // 注意用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
+    // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        topicDataSource?.let { ds ->
+            if (ds.items.isNotEmpty()) {
+                savedTopicsB64 = ds.items.map {
+                    android.util.Base64.encodeToString(it.toByteArray(), android.util.Base64.NO_WRAP)
                 }
+                savedTopicsLoadedPage = ds.loadedPage
             }
-            forumDataSource?.let { ds ->
-                if (ds.items.isNotEmpty()) {
-                    savedForumsB64 = ds.items.map {
-                        android.util.Base64.encodeToString(it.toByteArray(), android.util.Base64.NO_WRAP)
-                    }
-                    savedForumsLoadedPage = ds.loadedPage
+        }
+        forumDataSource?.let { ds ->
+            if (ds.items.isNotEmpty()) {
+                savedForumsB64 = ds.items.map {
+                    android.util.Base64.encodeToString(it.toByteArray(), android.util.Base64.NO_WRAP)
                 }
+                savedForumsLoadedPage = ds.loadedPage
             }
         }
     }

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/search/SearchScreen.kt
@@ -111,9 +111,6 @@ private enum class SearchTab(val titleKey: String, val history: SearchHistorySco
 fun SearchScreen(
     navigator: Navigator,
     forumId: ForumId? = null,
-    /** True when pushed fresh (vs. popped back to); fresh entries reset to the
-     * idle state, pop-backs resume query, results and scroll position. */
-    freshEntry: Boolean = false,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -141,19 +138,6 @@ fun SearchScreen(
     // field may attach a frame later than this effect, hence the guard.
     LaunchedEffect(Unit) {
         runCatching { fieldFocus.requestFocus() }
-    }
-
-    // 全新进入（push）：重置为初始态——空搜索框、无结果（显示历史）。
-    // pop 返回时不动：query/结果/滚动位置由 saveable 恢复。
-    LaunchedEffect(freshEntry) {
-        if (freshEntry) {
-            text = ""
-            committedText = null
-            savedTopicsB64 = emptyList()
-            savedTopicsLoadedPage = 0
-            savedForumsB64 = emptyList()
-            savedForumsLoadedPage = 0
-        }
     }
 
     val topicDataSource = remember(committedText, currentForumOnly, searchContent) {
@@ -308,9 +292,9 @@ fun SearchScreen(
                     val forumDS = forumDataSource
                     when {
                         tab == SearchTab.TOPICS && topicDS != null ->
-                            TopicResultsList(topicDS, navigator, freshEntry)
+                            TopicResultsList(topicDS, navigator)
                         tab == SearchTab.FORUMS && forumDS != null ->
-                            ForumResultsList(forumDS, navigator, freshEntry)
+                            ForumResultsList(forumDS, navigator)
                         else -> SearchHistorySection(
                             historyScope = tab.history,
                             onPick = { query ->

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
@@ -1,6 +1,5 @@
 package com.bugenzhao.mnga.ui.screens.topiclist
 
-import android.util.Base64
 import androidx.activity.compose.BackHandler
 
 import androidx.compose.foundation.layout.Box
@@ -49,7 +48,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -59,7 +57,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bugenzhao.mnga.App
 import com.bugenzhao.mnga.model.NavigationIdentifier
 import com.bugenzhao.mnga.model.PagingDataSource
@@ -104,8 +102,6 @@ fun TopicListScreen(
     mode: TopicListMode = TopicListMode.NORMAL,
     dateRange: Int = 0,
     editor: com.bugenzhao.mnga.ui.editor.EditorController? = null,
-    /** The stack route rendering this screen, used to tell a pop from a push. */
-    route: Route? = null,
 ) {
     val context = LocalContext.current
     val view = LocalView.current
@@ -138,48 +134,12 @@ fun TopicListScreen(
         return result
     }
 
-    // -- Data sources.
-    val (dataSourceLastPost, dataSourcePostDate) = remember(forumId) {
-        val lastPost = PagingDataSource<TopicListResponse, Topic>(
-            scope = scope,
-            responseParser = { TopicListResponse.parser() },
-            buildRequest = { page ->
-                AsyncRequest.newBuilder()
-                    .setTopicList(
-                        TopicListRequest.newBuilder()
-                            .setId(forumId)
-                            .setPage(page)
-                            .setOrder(TopicListRequest.Order.LAST_POST)
-                            .build()
-                    )
-                    .build()
-            },
-            onResponse = { response ->
-                Pair(maybeFiltered(response.topicsList), response.pages.toInt().takeIf { it > 0 })
-            },
-            id = { it.id },
-        )
-        val postDate = PagingDataSource<TopicListResponse, Topic>(
-            scope = scope,
-            responseParser = { TopicListResponse.parser() },
-            buildRequest = { page ->
-                AsyncRequest.newBuilder()
-                    .setTopicList(
-                        TopicListRequest.newBuilder()
-                            .setId(forumId)
-                            .setPage(page)
-                            .setOrder(TopicListRequest.Order.POST_DATE)
-                            .build()
-                    )
-                    .build()
-            },
-            onResponse = { response ->
-                Pair(maybeFiltered(response.topicsList), response.pages.toInt().takeIf { it > 0 })
-            },
-            id = { it.id },
-        )
-        lastPost to postDate
-    }
+    // -- Data sources: held by the entry-scoped ViewModel so the loaded data
+    // survives being covered by a pushed screen (composition is disposed,
+    // ViewModel is not) — no snapshot needed.
+    val topicListVM: TopicListViewModel = viewModel(
+        factory = TopicListViewModel.factory(forumId, mode),
+    )
 
     var hotRange by remember(forumId) {
         mutableStateOf(
@@ -187,116 +147,19 @@ fun TopicListScreen(
                 ?: HotTopicListRequest.DateRange.DAY
         )
     }
-    val hotDataSource = remember(forumId, hotRange) {
-        PagingDataSource<HotTopicListResponse, Topic>(
-            scope = scope,
-            responseParser = { HotTopicListResponse.parser() },
-            buildRequest = { _ ->
-                AsyncRequest.newBuilder()
-                    .setHotTopicList(
-                        HotTopicListRequest.newBuilder()
-                            .setId(forumId)
-                            .setRange(hotRange)
-                            .setFetchPageLimit(5)
-                            .build()
-                    )
-                    .build()
-            },
-            onResponse = { response -> Pair(response.topicsList, 1) },
-            id = { it.id },
-        )
-    }
-    val recommendedDataSource = remember(forumId) {
-        PagingDataSource<TopicListResponse, Topic>(
-            scope = scope,
-            responseParser = { TopicListResponse.parser() },
-            buildRequest = { page ->
-                AsyncRequest.newBuilder()
-                    .setTopicList(
-                        TopicListRequest.newBuilder()
-                            .setId(forumId)
-                            .setPage(page)
-                            .setOrder(TopicListRequest.Order.POST_DATE)
-                            .setRecommendedOnly(true)
-                            .build()
-                    )
-                    .build()
-            },
-            onResponse = { response ->
-                Pair(response.topicsList, response.pages.toInt().takeIf { it > 0 })
-            },
-            id = { it.id },
-        )
-    }
-
     val dataSource = when (mode) {
-        TopicListMode.HOT -> hotDataSource
-        TopicListMode.RECOMMENDED -> recommendedDataSource
+        TopicListMode.HOT -> topicListVM.hotDataSource(hotRange)
+        TopicListMode.RECOMMENDED -> topicListVM.recommendedDataSource
         TopicListMode.NORMAL ->
-            if (orderOrDefault == TopicListOrder.POST_DATE) dataSourcePostDate
-            else dataSourceLastPost
+            if (orderOrDefault == TopicListOrder.POST_DATE) topicListVM.dataSourcePostDate
+            else topicListVM.dataSourceLastPost
     }
     val state by dataSource.state.collectAsState()
 
-    // -- Keep the loaded topic list across navigation: when this screen is
-    // pushed away (e.g. into a topic details page) and popped back, restore
-    // the previous items/page/scroll instead of refetching and jumping to top.
-    var savedItemsB64 by rememberSaveable(forumId, mode) { mutableStateOf<List<String>>(emptyList()) }
-    var savedLoadedPage by rememberSaveable(forumId, mode) { mutableStateOf(0) }
-    var savedTotalPages by rememberSaveable(forumId, mode) { mutableStateOf(1) }
-    var savedLastRefresh by rememberSaveable(forumId, mode) { mutableStateOf(0L) }
-    var savedResponseB64 by rememberSaveable(forumId, mode) { mutableStateOf<String?>(null) }
-
+    // Load on first entry only: after a pop-back the ViewModel still holds the
+    // data, so notLoaded is false and nothing is refetched.
     LaunchedEffect(dataSource) {
-        if (savedItemsB64.isNotEmpty()) {
-            val parser =
-                when (dataSource) {
-                    hotDataSource -> HotTopicListResponse.parser()
-                    else -> TopicListResponse.parser()
-                }
-            dataSource.restoreItems(
-                items = savedItemsB64.map { Topic.parseFrom(Base64.decode(it, Base64.NO_WRAP)) },
-                loadedPage = savedLoadedPage,
-                totalPages = savedTotalPages,
-                lastRefreshTime = savedLastRefresh.takeIf { it > 0 }?.let { java.util.Date(it) },
-                latestResponse = savedResponseB64?.let {
-                    parser.parseFrom(Base64.decode(it, Base64.NO_WRAP))
-                },
-            )
-        } else {
-            dataSource.initialLoad()
-        }
-    }
-
-    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
-        // Only keep the snapshot when this screen was pushed away by a
-        // deeper route (so popping back restores it). When the route was
-        // popped off the stack for good, drop the snapshot so the next
-        // entry into this forum starts fresh instead of showing the
-        // stale list.
-        // 注意：NavHost 下 entry 的 route 实例与 navigator.stack 中解码出的
-        // 实例不是同一个对象，必须用值相等（Route 是 data class）。
-        // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
-        // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
-        val stillInStack = route != null && navigator.stack.value.any { it == route }
-        if (stillInStack && dataSource.items.isNotEmpty()) {
-            savedItemsB64 = dataSource.items.map {
-                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
-            }
-            savedLoadedPage = dataSource.loadedPage
-            savedTotalPages = dataSource.totalPages
-            savedLastRefresh = dataSource.lastRefreshTime?.time ?: 0L
-            savedResponseB64 =
-                (dataSource.latestResponse as? com.google.protobuf.Message)
-                    ?.toByteArray()
-                    ?.let { Base64.encodeToString(it, Base64.NO_WRAP) }
-        } else if (!stillInStack) {
-            savedItemsB64 = emptyList()
-            savedLoadedPage = 0
-            savedTotalPages = 1
-            savedLastRefresh = 0L
-            savedResponseB64 = null
-        }
+        if (dataSource.notLoaded) dataSource.initialLoad()
     }
 
     // -- Forum meta enrichment (SS5 updateForumMeta).
@@ -559,10 +422,6 @@ fun TopicListScreen(
                 showInitialLoading = false,
                 emptyPlaceholder = L.str(context, "No Results"),
                 header = header,
-                // A fresh entry (no restored snapshot) must start at the top:
-                // the saveable scroll position would otherwise be restored
-                // from the route registry even though the data was reloaded.
-                freshEntry = savedItemsB64.isEmpty(),
                 scrollToTopSignal = refreshScrollEpoch,
                 itemContent = { _, topic ->
                     TopicListItem(

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.bugenzhao.mnga.App
 import com.bugenzhao.mnga.model.NavigationIdentifier
 import com.bugenzhao.mnga.model.PagingDataSource
@@ -267,34 +268,34 @@ fun TopicListScreen(
         }
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            // Only keep the snapshot when this screen was pushed away by a
-            // deeper route (so popping back restores it). When the route was
-            // popped off the stack for good, drop the snapshot so the next
-            // entry into this forum starts fresh instead of showing the
-            // stale list.
-            // 注意：NavHost 下 entry 的 route 实例与 navigator.stack 中解码出的
-            // 实例不是同一个对象，必须用值相等（Route 是 data class）。
-            val stillInStack = route != null && navigator.stack.value.any { it == route }
-            if (stillInStack && dataSource.items.isNotEmpty()) {
-                savedItemsB64 = dataSource.items.map {
-                    Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
-                }
-                savedLoadedPage = dataSource.loadedPage
-                savedTotalPages = dataSource.totalPages
-                savedLastRefresh = dataSource.lastRefreshTime?.time ?: 0L
-                savedResponseB64 =
-                    (dataSource.latestResponse as? com.google.protobuf.Message)
-                        ?.toByteArray()
-                        ?.let { Base64.encodeToString(it, Base64.NO_WRAP) }
-            } else if (!stillInStack) {
-                savedItemsB64 = emptyList()
-                savedLoadedPage = 0
-                savedTotalPages = 1
-                savedLastRefresh = 0L
-                savedResponseB64 = null
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        // Only keep the snapshot when this screen was pushed away by a
+        // deeper route (so popping back restores it). When the route was
+        // popped off the stack for good, drop the snapshot so the next
+        // entry into this forum starts fresh instead of showing the
+        // stale list.
+        // 注意：NavHost 下 entry 的 route 实例与 navigator.stack 中解码出的
+        // 实例不是同一个对象，必须用值相等（Route 是 data class）。
+        // 用 ON_STOP 而不是 DisposableEffect.onDispose：onDispose 时
+        // SaveableStateHolder 可能已经拍过状态快照，写入会被丢弃。
+        val stillInStack = route != null && navigator.stack.value.any { it == route }
+        if (stillInStack && dataSource.items.isNotEmpty()) {
+            savedItemsB64 = dataSource.items.map {
+                Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)
             }
+            savedLoadedPage = dataSource.loadedPage
+            savedTotalPages = dataSource.totalPages
+            savedLastRefresh = dataSource.lastRefreshTime?.time ?: 0L
+            savedResponseB64 =
+                (dataSource.latestResponse as? com.google.protobuf.Message)
+                    ?.toByteArray()
+                    ?.let { Base64.encodeToString(it, Base64.NO_WRAP) }
+        } else if (!stillInStack) {
+            savedItemsB64 = emptyList()
+            savedLoadedPage = 0
+            savedTotalPages = 1
+            savedLastRefresh = 0L
+            savedResponseB64 = null
         }
     }
 

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListScreen.kt
@@ -274,7 +274,9 @@ fun TopicListScreen(
             // popped off the stack for good, drop the snapshot so the next
             // entry into this forum starts fresh instead of showing the
             // stale list.
-            val stillInStack = route != null && navigator.stack.value.any { it === route }
+            // 注意：NavHost 下 entry 的 route 实例与 navigator.stack 中解码出的
+            // 实例不是同一个对象，必须用值相等（Route 是 data class）。
+            val stillInStack = route != null && navigator.stack.value.any { it == route }
             if (stillInStack && dataSource.items.isNotEmpty()) {
                 savedItemsB64 = dataSource.items.map {
                     Base64.encodeToString(it.toByteArray(), Base64.NO_WRAP)

--- a/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListViewModel.kt
+++ b/app/src/main/java/com/bugenzhao/mnga/ui/screens/topiclist/TopicListViewModel.kt
@@ -1,0 +1,136 @@
+package com.bugenzhao.mnga.ui.screens.topiclist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.bugenzhao.mnga.App
+import com.bugenzhao.mnga.model.PagingDataSource
+import com.bugenzhao.mnga.protos.datamodel.ForumId
+import com.bugenzhao.mnga.protos.datamodel.Topic
+import com.bugenzhao.mnga.protos.service.AsyncRequest
+import com.bugenzhao.mnga.protos.service.HotTopicListRequest
+import com.bugenzhao.mnga.protos.service.HotTopicListResponse
+import com.bugenzhao.mnga.protos.service.TopicListRequest
+import com.bugenzhao.mnga.protos.service.TopicListResponse
+import com.bugenzhao.mnga.storage.BlockWordsStorage
+import com.bugenzhao.mnga.ui.nav.TopicListMode
+
+/**
+ * Entry-scoped holder of the forum's paged topic lists.
+ *
+ * NavHost scopes [ViewModel]s to the back-stack entry: when the entry is
+ * covered, its composition is disposed but the ViewModel (and the loaded
+ * data) survives, so popping back reuses it instead of refetching — no
+ * manual snapshot needed. The ViewModel is cleared (and data refetched)
+ * when the entry leaves the back stack or the process dies.
+ */
+class TopicListViewModel(
+    private val forumId: ForumId,
+    private val mode: TopicListMode,
+) : ViewModel() {
+
+    /** Block words + forum-shortcut filtering (SS5 maybeFiltered). */
+    private fun maybeFiltered(topics: List<Topic>): List<Topic> {
+        var result = topics
+        if (App.prefs.topicListHideBlocked.value) {
+            result = result.filter { !App.blockWords.blocked(BlockWordsStorage.content(it)) }
+        }
+        if (!App.prefs.topicListShowForumShortcut.value) {
+            result = result.filter { !it.hasShortcutForum() }
+        }
+        return result
+    }
+
+    val dataSourceLastPost = PagingDataSource<TopicListResponse, Topic>(
+        scope = viewModelScope,
+        responseParser = { TopicListResponse.parser() },
+        buildRequest = { page ->
+            AsyncRequest.newBuilder()
+                .setTopicList(
+                    TopicListRequest.newBuilder()
+                        .setId(forumId)
+                        .setPage(page)
+                        .setOrder(TopicListRequest.Order.LAST_POST)
+                        .build()
+                )
+                .build()
+        },
+        onResponse = { response ->
+            Pair(maybeFiltered(response.topicsList), response.pages.toInt().takeIf { it > 0 })
+        },
+        id = { it.id },
+    )
+
+    val dataSourcePostDate = PagingDataSource<TopicListResponse, Topic>(
+        scope = viewModelScope,
+        responseParser = { TopicListResponse.parser() },
+        buildRequest = { page ->
+            AsyncRequest.newBuilder()
+                .setTopicList(
+                    TopicListRequest.newBuilder()
+                        .setId(forumId)
+                        .setPage(page)
+                        .setOrder(TopicListRequest.Order.POST_DATE)
+                        .build()
+                )
+                .build()
+        },
+        onResponse = { response ->
+            Pair(maybeFiltered(response.topicsList), response.pages.toInt().takeIf { it > 0 })
+        },
+        id = { it.id },
+    )
+
+    val recommendedDataSource = PagingDataSource<TopicListResponse, Topic>(
+        scope = viewModelScope,
+        responseParser = { TopicListResponse.parser() },
+        buildRequest = { page ->
+            AsyncRequest.newBuilder()
+                .setTopicList(
+                    TopicListRequest.newBuilder()
+                        .setId(forumId)
+                        .setPage(page)
+                        .setOrder(TopicListRequest.Order.POST_DATE)
+                        .setRecommendedOnly(true)
+                        .build()
+                )
+                .build()
+        },
+        onResponse = { response ->
+            Pair(maybeFiltered(response.topicsList), response.pages.toInt().takeIf { it > 0 })
+        },
+        id = { it.id },
+    )
+
+    // The hot list is per date-range; ranges are a small fixed enum, cache them.
+    private val hotSources =
+        mutableMapOf<HotTopicListRequest.DateRange, PagingDataSource<HotTopicListResponse, Topic>>()
+
+    fun hotDataSource(range: HotTopicListRequest.DateRange): PagingDataSource<HotTopicListResponse, Topic> =
+        hotSources.getOrPut(range) {
+            PagingDataSource(
+                scope = viewModelScope,
+                responseParser = { HotTopicListResponse.parser() },
+                buildRequest = { _ ->
+                    AsyncRequest.newBuilder()
+                        .setHotTopicList(
+                            HotTopicListRequest.newBuilder()
+                                .setId(forumId)
+                                .setRange(range)
+                                .setFetchPageLimit(5)
+                                .build()
+                        )
+                        .build()
+                },
+                onResponse = { response -> Pair(response.topicsList, 1) },
+                id = { it.id },
+            )
+        }
+
+    companion object {
+        fun factory(forumId: ForumId, mode: TopicListMode) = viewModelFactory {
+            initializer { TopicListViewModel(forumId, mode) }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ coil = "2.7.0"
 protobuf = "4.35.1"
 coroutines = "1.10.2"
 annotation = "1.9.1"
+navigationCompose = "2.9.0"
 buglyCrash = "4.1.9"
 buglyNative = "3.9.2"
 
@@ -26,6 +27,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "annotation" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
 bugly-crashreport = { group = "com.tencent.bugly", name = "crashreport", version.ref = "buglyCrash" }


### PR DESCRIPTION
## 概述

把自定义导航栈迁移到 **Navigation Compose (NavHost)**，并修复迁移过程中发现的一系列相关问题。

## 主要变更

### 导航迁移（核心）
- 新增 `RouteCodec`：Route ↔ 路由串编解码（每类型一个 pattern，参数打包为 URL 编码 JSON payload，含 ForumId/User proto 字段往返）
- `Navigator` 内部改为驱动 `NavHostController`，**公开 API 不变**（push/pop/stack/size/lastOp），99 处调用点零改动
- `NavigationHost` 换成 `NavHost` + 19 条路由表 + 同款 280ms push/pop 转场；删除手写 `SaveableStateProvider`/`routeKey`/`AnimatedContent`
- NavHost 按 entry 保存状态：**新压栈 = 全新状态，pop 返回 = 恢复原状**（修复此前"fresh 进入恢复旧状态"的 bug）
- 删除 SearchScreen/SearchResults 的 freshEntry 补丁

### 数据跨页保留（官方 ViewModel 方案）
- `TopicListViewModel` / `FavoritesViewModel` / `ForumListViewModel`：数据源移入 **entry 作用域 ViewModel**，被盖住时数据存活，返回零重拉（替换手写 Base64 快照）
- 首页收藏版块同步逻辑移入 ViewModel（修复返回首页时 `forum_favor2` 无条件重拉）
- SearchScreen 保留快照方案（查询词驱动的动态数据源不适合固定资源模式）

### 相关修复
- MainActivity 改 `singleTop`：深链可靠投递（修复 OPPO 上"delivered to top-most 不导航"）
- 关闭预测性返回：全面屏手势**松开才触发退出动画**（滑动中不再提前播放/取消回弹）
- 搜索页「搜索正文」默认关

### 其他
- CI 改为所有分支 push 触发

## 验证

- OPPO 实机全量回归：push/pop、滚动保持、搜索语义（新进空态/返回恢复）、深链（冷启动/onNewIntent/单实例）、双击退出、进程死亡恢复、视频播放（后台自动暂停/恢复）、收藏/首页返回零重拉
- 无崩溃（logcat 全程无 FATAL）
